### PR TITLE
Create _redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
 /api/* https://orgbattleground.herokuapp.com/
+/* /index.html 200


### PR DESCRIPTION
Reason: The front-end application currently accesses an API on a different host.

Adding a redirects file will allow proxying of requests on the primary domain.